### PR TITLE
show variant sku instead of product sku to sellers

### DIFF
--- a/app/views/spree/admin/sellers/prices/index.html.erb
+++ b/app/views/spree/admin/sellers/prices/index.html.erb
@@ -12,7 +12,7 @@
       <tr data-hook="admin_offers_index_headers">
         <th><%= Spree::Variant.model_name.human %></th>
         <th></th>
-        <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
+        <th><%= Spree::Price.human_attribute_name(:sku) %></th>
         <th><%= Spree::Price.human_attribute_name(:country) %></th>
         <th><%= Spree::Price.human_attribute_name(:amount) %></th>
         <th><%= Spree::Price.human_attribute_name(:seller_stock_availability)%></th>
@@ -25,7 +25,7 @@
           <td class="align-center">
               <%= render 'spree/admin/shared/image', image: price.product.gallery.images.first, size: :mini %>
           </td>
-          <td><%= price.product.sku %></td>
+          <td><%= price.variant.sku %></td>
           <td><%= price.display_country %></td>
           <td><%= price.display_price.to_html %></td>
           <td><%= price.seller_stock_availability %></td>


### PR DESCRIPTION
show the correct SKU value in sellers offers index (at the moment the `product` SKU is show instead of the `variant` one)