### PR TITLE
Redirect sellers to dashboard after sign in

### DIFF
--- a/app/decorators/controllers/manage_seller_users_in_admin_root_controller_decorator.rb
+++ b/app/decorators/controllers/manage_seller_users_in_admin_root_controller_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ManageSellerUsersInAdminRootControllerDecorator
+  def index
+    if current_spree_user&.has_spree_role?(:seller)
+      redirect_to admin_sellers_dashboard_path
+    else
+      super
+    end
+  end
+
+  Spree::Admin::RootController.prepend(self)
+end

--- a/spec/decorators/controllers/manage_seller_users_in_admin_root_controller_decorator_spec.rb
+++ b/spec/decorators/controllers/manage_seller_users_in_admin_root_controller_decorator_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ManageSellerUsersInAdminRootControllerDecorator, type: :controller do
+  include Devise::Test::ControllerHelpers
+  let(:user) { create(:user) }
+
+  before do
+    sign_in(user)
+    @controller = Spree::Admin::RootController.new
+  end
+
+  describe '#index' do
+    it 'redirects to admin root' do
+      get :index
+      expect(response).to be_redirect
+      expect(response).not_to redirect_to('/unauthorized')
+    end
+
+    context 'when user has seller role' do
+      let(:user) { create(:seller_user, seller: create(:seller)) }
+
+      it 'redirects to seller dashboard' do
+        get :index
+        expect(response).to redirect_to(spree.admin_sellers_dashboard_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a login redirect dedicated to users with the "seller" role.

This has the benefit of preventing normal admin login redirects that result in a "unauthorized" message.

resolve #35 