### PR TITLE
Validate seller presence if user has seller role

### DIFF
--- a/app/decorators/add_seller_to_user_decorator.rb
+++ b/app/decorators/add_seller_to_user_decorator.rb
@@ -4,6 +4,8 @@ module AddSellerToUserDecorator
   def self.prepended(base)
     base.belongs_to :seller, class_name: 'Spree::Seller',
                              optional: true
+
+    base.validates_presence_of :seller, if: -> { has_spree_role?(:seller) }
   end
 
   Spree::User.prepend self

--- a/lib/spree/permission_sets/seller_navigation.rb
+++ b/lib/spree/permission_sets/seller_navigation.rb
@@ -4,9 +4,6 @@ module Spree
   module PermissionSets
     class SellerNavigation < PermissionSets::Base
       def activate!
-        # NB: leaving this guard since seller presence is not validated yet for users with `seller` role
-        return unless user.seller
-
         can :visit, :paypal_callbacks
         can :visit, :seller_dashboard
         can :visit, :seller_prices if user.seller.accepted?

--- a/lib/spree/permission_sets/seller_resources.rb
+++ b/lib/spree/permission_sets/seller_resources.rb
@@ -4,8 +4,7 @@ module Spree
   module PermissionSets
     class SellerResources < PermissionSets::Base
       def activate!
-        # NB: leaving this guard since seller presence is not validated yet for users with `seller` role
-        return unless user.seller_id && user.seller.accepted?
+        return unless user.seller.accepted?
 
         can :manage, Spree::Price, seller_id: user.seller_id
         can :manage, Spree::Shipment, stock_location: { seller_id: user.seller_id }

--- a/spec/decorators/add_seller_to_user_decorator_spec.rb
+++ b/spec/decorators/add_seller_to_user_decorator_spec.rb
@@ -11,4 +11,18 @@ RSpec.describe AddSellerToUserDecorator, type: :model do
       .class_name('Spree::Seller')
       .optional
   end
+
+  it do
+    expect(described_class.new).not_to validate_presence_of(:seller)
+  end
+
+  context 'when has seller role' do
+    subject(:seller_user) { described_class.new(spree_roles: [seller_role]) }
+
+    let(:seller_role) { create(:role, name: 'seller') }
+
+    it do
+      expect(seller_user).to validate_presence_of(:seller)
+    end
+  end
 end

--- a/spec/lib/spree/permission_sets/seller_resources_price_spec.rb
+++ b/spec/lib/spree/permission_sets/seller_resources_price_spec.rb
@@ -27,13 +27,6 @@ RSpec.describe Spree::PermissionSets::SellerResources do
       expect(ability).to be_able_to([:create, :update, :destroy], seller_price)
     end
 
-    context 'without seller_id' do
-      it 'cannot manage base price' do
-        user.update!(seller_id: nil)
-        expect(ability).not_to be_able_to([:create, :update, :destroy], price)
-      end
-    end
-
     context 'when is rejected' do
       it 'cannot manage his price' do
         seller.update!(status: :rejected)

--- a/spec/lib/spree/permission_sets/seller_resources_shipment_spec.rb
+++ b/spec/lib/spree/permission_sets/seller_resources_shipment_spec.rb
@@ -39,13 +39,6 @@ RSpec.describe Spree::PermissionSets::SellerResources do
       end
     end
 
-    context 'without seller_id' do
-      it 'cannot manage base shipment' do
-        user.update!(seller_id: nil)
-        expect(ability).not_to be_able_to([:create, :update, :destroy], shipment)
-      end
-    end
-
     context 'when is rejected' do
       it 'cannot manage his shipment' do
         seller.update!(status: :rejected)


### PR DESCRIPTION
Users with `seller` role should always have an associated seller

close #47 