### PR TITLE
Add possibility to set merchant_id for seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ According to this will or not be able to use the platfform.
 
 ## Development
 
-Step to test the seller onboarding process using localtunner.
+Step to test the seller onboarding process using localtunnel.
 
 1) npm install -g localtunnel
 2) lt --port 3000
@@ -97,6 +97,23 @@ $ bin/rails server
 => Rails 6.0.2.1 application starting in development
 * Listening on tcp://127.0.0.1:3000
 Use Ctrl-C to stop
+```
+
+### Preserving the seeds
+Seeds loader will search for a `DEFAULT_MERCHANT_ID` and `DEFAULT_MERCHANT_ID_IN_PAYPAL` env variables to load in the default seller,
+or even for an array of sellers data inside a `SELLER_SEEDS` env variable (this should be JSON encoded).
+This can help preserving sellers across sandbox resets.
+```
+# Default data
+
+DEFAULT_MERCHANT_ID=00000000-0000-0000-0000-000000000000
+DEFAULT_MERCHANT_ID_IN_PAYPAL=XXXXXXXXXXXXX
+
+# Custom data
+# NB: Seller JSON data is easy obtainable with a query like
+# `Spree::Seller.select(:name, :percentage, :merchant_id, :merchant_id_in_paypal).to_json`
+
+SELLER_SEEDS="[{\"name\":\"Seller A\",\"percentage\":10.0,\"merchant_id\":\"11111111-1111-1111-1111-111111111111\",\"merchant_id_in_paypal\":\"AAAAAAAAAAAAA\"},{\"name\":\"Seller B\",\"percentage\":20.0,\"merchant_id\":null,\"merchant_id_in_paypal\":null\}]"
 ```
 
 ### Updating the changelog

--- a/app/models/spree/seller.rb
+++ b/app/models/spree/seller.rb
@@ -31,7 +31,8 @@ module Spree
 
     accepts_nested_attributes_for :users, reject_if: :all_blank
 
-    before_validation :set_merchant_id, on: :create
+    before_validation :set_merchant_id, if: -> { merchant_id.blank? },
+                                        on: :create
     before_validation :assign_seller_role_to_users, if: -> { users.present? },
                                                     on: :create
 

--- a/db/default/spree/seller.rb
+++ b/db/default/spree/seller.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
 unless Spree::Seller.where(name: 'Seller').exists?
-  Spree::Seller.create!(name: 'Seller', percentage: 20)
+  status = ENV['DEFAULT_MERCHANT_ID'] && ENV['DEFAULT_MERCHANT_ID_IN_PAYPAL'] ? :accepted : :pending
+  Spree::Seller.create!(
+    name: 'Seller',
+    percentage: 20,
+    merchant_id: ENV['DEFAULT_MERCHANT_ID'],
+    merchant_id_in_paypal: ENV['DEFAULT_MERCHANT_ID_IN_PAYPAL'],
+    status: status
+  )
+end
+if ENV['SELLER_SEEDS'].present?
+  seeds = JSON.parse(ENV['SELLER_SEEDS'])
+  seeds.each.with_index do |seed, index|
+    name = seed['name'] || index
+    Spree::Seller.find_or_initialize_by(name: name).tap do |seller|
+      seller.percentage = seed['percentage'] || 10
+      seller.merchant_id = seed['merchant_id']
+      seller.merchant_id_in_paypal = seed['merchant_id_in_paypal']
+      status = seller.merchant_id && seller.merchant_id_in_paypal ? :accepted : :pending
+      seller.status = status
+      seller.save
+    end
+  end
 end

--- a/spec/models/spree/seller_spec.rb
+++ b/spec/models/spree/seller_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe Spree::Seller, type: :model do
       expect(seller.merchant_id).to be_present
     end
 
+    context 'when merchant id is present' do
+      let(:seller) { described_class.new(merchant_id: 'merchant-id') }
+
+      it 'does not override it' do
+        expect { seller.save }.not_to(change(seller, :merchant_id))
+      end
+    end
+
     it 'creates default stock location' do
       expect { seller }.to change(Spree::StockLocation, :count).from(0)
     end


### PR DESCRIPTION
Allow developers to persist merchant_id between sandbox resets

close #54 