### PR TITLE
Generate api key on user with seller role creation

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -9,6 +9,8 @@ Spree.config do |config|
     'Spree::PermissionSets::SellerResources'
   ]
 
+  config.roles_for_auto_api_key << 'seller'
+
   config.variant_price_selector_class = Spree::Variant::SellersPriceSelector
   config.stock.coordinator_class = 'SolidusPaypalMarketplace::Stock::MarketplaceCoordinator'
 end

--- a/db/default/spree/seller_user.rb
+++ b/db/default/spree/seller_user.rb
@@ -46,12 +46,11 @@ def create_seller_user
     puts "\nWARNING: There is already a user with the email: #{email}, so no account changes were made.\n\n"
   else
     seller_user = Spree.user_class.new(attributes)
+    role = Spree::Role.find_or_create_by(name: 'seller')
+    seller_user.spree_roles << role
+    seller_user.seller = Spree::Seller.first
+    seller_user.generate_spree_api_key unless seller_user.spree_api_key
     if seller_user.save
-      role = Spree::Role.find_or_create_by(name: 'seller')
-      seller_user.spree_roles << role
-      seller_user.seller = Spree::Seller.first
-      seller_user.save
-      seller_user.generate_spree_api_key!
       puts 'Done!'
     else
       puts "There were some problems with persisting a new seller user:"

--- a/spec/models/spree/user_with_seller_role_spec.rb
+++ b/spec/models/spree/user_with_seller_role_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe Spree::User, type: :model do
+  subject(:seller_user) { create(:seller_user) }
+
+  it do
+    expect(seller_user.spree_api_key).to be_present
+  end
+end


### PR DESCRIPTION
This allow sellers accounts to use dynamic menus relying on APIs

close #56 