### PR TITLE
Utilize Rails redirect helpers

### DIFF
--- a/app/decorators/controllers/add_seller_to_populate_orders_controller_decorator.rb
+++ b/app/decorators/controllers/add_seller_to_populate_orders_controller_decorator.rb
@@ -24,7 +24,11 @@ module AddSellerToPopulateOrdersControllerDecorator
       format.html do
         if @order.errors.any?
           flash[:error] = @order.errors.full_messages.join(", ")
-          redirect_back_or_default(spree.root_path)
+          if Rails.gem_version > Gem::Version.new('7.0')
+            redirect_back_or_to(spree.root_path)
+          else
+            redirect_back(fallback_location: spree.root_path)
+          end
           return
         else
           redirect_to cart_path


### PR DESCRIPTION
## Description
Removes #redirect_back_or_default in favor of Rails #redirect_back and #redirect_back_or_to

## Motivation and Context
Rails introduced redirect_back in rails 5+ and redirect_back_or_to in rails 7+. These methods should be utilized instead of the redirect method created by Soldius, which similarly replicates the functionality of the deprecated method.
The method #redirect_back_or_default will be deprecated in Solidus [PR #4533](https://github.com/solidusio/solidus/pull/4533)

## How Has This Been Tested?
The current test suite covers the changes made in the PR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
